### PR TITLE
fix rootless usage by running node-ci as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ RUN \
     /tmp/pairdrop.tar.gz -C \
     /app/pairdrop/ --strip-components=1 && \
   cd /app/pairdrop && \
-  npm ci && \
+  adduser -D node && \
+  chown -R node:node ./ && \
+  su node -c 'npm ci' && \
   echo "**** cleanup ****" && \
   rm -rf \
     $HOME/.cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN \
   rm -rf \
     $HOME/.cache \
     /tmp/* \
+    /home/node/.npm \
     /app/.npm
 
 # copy local files


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-pairdrop/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:
Fixes #4 (rootless usage) by changing node-ci call to be run as non-root user

## Benefits of this PR and context:
Allow use in rootless environments

## How Has This Been Tested?
Ran container, verified basic nominal behavior

## Source / References:
